### PR TITLE
Display options

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	fmt.Printf("Namespace: %s\n", namespace)
+	fmt.Printf("Labels:    %s\n\n", labels)
+
 	deployments, err := clientset.Deployments(namespace).List(v1.ListOptions{
 		LabelSelector: labels,
 	})


### PR DESCRIPTION
## WHY

```bash
$ ./bin/kubeps --labels role --namespace=docker-hello-world
Namespace: docker-hello-world
Labels:    role

=== Deployment ===
NAME                    IMAGE                           NAMESPACE
docker-hello-world      koudaiii/hello-world:3959aca    docker-hello-world

=== Pod ===
NAME                                    IMAGE                           STATUS  RESTARTS        START                           NAMESPACE
docker-hello-world-2473057991-9ftt0     koudaiii/hello-world:3959aca    Running 0               2016-11-18 14:27:21 +0900 JST   docker-hello-world
```
