### PR TITLE
Supported short options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME      := kubeps
-VERSION   := v0.2.1
+VERSION   := v0.2.2
 REVISION  := $(shell git rev-parse --short HEAD)
 
 SRCS      := $(shell find . -name '*.go' -type f)

--- a/main.go
+++ b/main.go
@@ -31,8 +31,8 @@ func main() {
 	}
 
 	flags.StringVar(&kubeconfig, "kubeconfig", "", "Path of kubeconfig")
-	flags.StringVar(&labels, "labels", "", "Label filter query")
-	flags.StringVar(&namespace, "namespace", "", "Kubernetes namespace")
+	flags.StringVarP(&labels, "labels", "l", "", "Label filter query")
+	flags.StringVarP(&namespace, "namespace", "n", "", "Kubernetes namespace")
 	flags.BoolVarP(&version, "version", "v", false, "Print version")
 
 	if err := flags.Parse(os.Args[1:]); err != nil {


### PR DESCRIPTION
## WHY

kubectl is supported short options.
kubeps also should be supported short options.

## WHAT

- add `-l`, `-n`

```
$ ./bin/kubeps -h
      --kubeconfig string   Path of kubeconfig
  -l, --labels string       Label filter query
  -n, --namespace string    Kubernetes namespace
  -v, --version             Print version
```

