### PR TITLE
Add finishedAt

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ var (
 	namespace     string
 	labels        string
 	version       bool
-	podColumns    = []string{"NAME", "IMAGE", "STATUS", "READY", "RESTARTS", "START", "NAMESPACE"}
+	podColumns    = []string{"NAME", "IMAGE", "STATUS", "READY", "RESTARTS", "START", "LAST", "NAMESPACE"}
 	deployColumns = []string{"NAME", "IMAGE", "NAMESPACE"}
 )
 
@@ -122,6 +122,7 @@ func main() {
 						strconv.FormatInt(int64(readyContainers), 10) + "/" + strconv.FormatInt(int64(len(pod.Spec.Containers)), 10),
 						strconv.FormatInt(int64(pod.Status.ContainerStatuses[0].RestartCount), 10),
 						pod.Status.StartTime.String(),
+						finishedAt(pod.Status.ContainerStatuses[0]),
 						pod.Namespace,
 					}, "\t",
 				))
@@ -134,6 +135,7 @@ func main() {
 						strconv.FormatInt(int64(readyContainers), 10) + "/" + strconv.FormatInt(int64(len(pod.Spec.Containers)), 10),
 						"<none>",
 						"<none>",
+						"<none>",
 						pod.Namespace,
 					}, "\t",
 				))
@@ -144,4 +146,11 @@ func main() {
 	podPrint.Flush()
 	fmt.Println()
 
+}
+
+func finishedAt(n v1.ContainerStatus) string {
+	if n.State.Terminated != nil && n.State.Terminated.Reason == "Completed" {
+		return n.State.Terminated.FinishedAt.String()
+	}
+	return "<none>"
 }


### PR DESCRIPTION
## WHY

Add finished at in pod for job.

## WHAT

- before

```shell-session
$ kubeps 
Namespace: 
Labels:    

=== Deployment ===
NAME		IMAGE								NAMESPACE
kube-dns	gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4		kube-system
kube-dns	gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4	kube-system
kube-dns	gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4		kube-system
myapp		quay.io/koudaiii/myapp:latest					myapp
myapp		nginx:1.13.3-alpine						myapp
postgres	postgres:9.6.5							myapp

=== Pod ===
NAME							IMAGE								STATUS		READY	RESTARTS	START				NAMESPACE
kube-addon-manager-minikube				gcr.io/google-containers/kube-addon-manager:v6.4-beta.2		Running		1/1	1		2017-09-10 23:25:33 +0900 JST	kube-system
kube-dns-910330662-hkvmq				gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4		Running		3/3	1		2017-09-10 23:25:36 +0900 JST	kube-system
kube-dns-910330662-hkvmq				gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4	Running		3/3	1		2017-09-10 23:25:36 +0900 JST	kube-system
kube-dns-910330662-hkvmq				gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4		Running		3/3	1		2017-09-10 23:25:36 +0900 JST	kube-system
kubernetes-dashboard-2jl6t				gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.3	Running		1/1	1		2017-09-10 23:25:36 +0900 JST	kube-system
db-migrate-koudaiii-2017091116251505114716-707pt	quay.io/koudaiii/myapp:946bd19					Succeeded	0/1	0		2017-09-11 16:16:56 +0900 JST	myapp
myapp-2136627869-2qlm1					quay.io/koudaiii/myapp:latest					Running		2/2	1		2017-09-11 18:07:43 +0900 JST	myapp
myapp-2136627869-2qlm1					nginx:1.13.3-alpine						Running		2/2	1		2017-09-11 18:07:43 +0900 JST	myapp
myapp-2136627869-6w3mj					quay.io/koudaiii/myapp:latest					Running		2/2	1		2017-09-11 18:06:26 +0900 JST	myapp
myapp-2136627869-6w3mj					nginx:1.13.3-alpine						Running		2/2	1		2017-09-11 18:06:26 +0900 JST	myapp
myapp-2136627869-dcvw3					quay.io/koudaiii/myapp:latest					Running		2/2	1		2017-09-11 18:07:20 +0900 JST	myapp
myapp-2136627869-dcvw3					nginx:1.13.3-alpine						Running		2/2	1		2017-09-11 18:07:20 +0900 JST	myapp
myapp-2136627869-kwlhx					quay.io/koudaiii/myapp:latest					Running		2/2	1		2017-09-11 18:06:26 +0900 JST	myapp
myapp-2136627869-kwlhx					nginx:1.13.3-alpine						Running		2/2	1		2017-09-11 18:06:26 +0900 JST	myapp
myapp-job-1505118600-sr7wn				quay.io/koudaiii/myapp:latest					Succeeded	0/1	0		2017-09-11 17:30:05 +0900 JST	myapp
myapp-job-1505119500-dgc2d				quay.io/koudaiii/myapp:latest					Succeeded	0/1	0		2017-09-11 17:45:06 +0900 JST	myapp
myapp-job-1505120400-zbp9s				quay.io/koudaiii/myapp:latest					Succeeded	0/1	0		2017-09-11 18:00:08 +0900 JST	myapp
myapp-job-1505121300-cjgrt				quay.io/koudaiii/myapp:latest					Succeeded	0/1	0		2017-09-11 18:15:01 +0900 JST	myapp
myapp-job-1505122200-0pn60				quay.io/koudaiii/myapp:latest					Succeeded	0/1	0		2017-09-11 18:30:02 +0900 JST	myapp
postgres-2312165663-5vzcs				postgres:9.6.5							Running		1/1	1		2017-09-11 09:52:18 +0900 JST	myapp
```

- after

```shell-session
$ ./bin/kubeps 
Namespace: 
Labels:    

=== Deployment ===
NAME		IMAGE								NAMESPACE
kube-dns	gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4		kube-system
kube-dns	gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4	kube-system
kube-dns	gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4		kube-system
myapp		quay.io/koudaiii/myapp:latest					myapp
myapp		nginx:1.13.3-alpine						myapp
postgres	postgres:9.6.5							myapp

=== Pod ===
NAME							IMAGE								STATUS		READY	RESTARTS	START				LAST				NAMESPACE
kube-addon-manager-minikube				gcr.io/google-containers/kube-addon-manager:v6.4-beta.2		Running		1/1	1		2017-09-10 23:25:33 +0900 JST	<none>				kube-system
kube-dns-910330662-hkvmq				gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4		Running		3/3	1		2017-09-10 23:25:36 +0900 JST	<none>				kube-system
kube-dns-910330662-hkvmq				gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4	Running		3/3	1		2017-09-10 23:25:36 +0900 JST	<none>				kube-system
kube-dns-910330662-hkvmq				gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4		Running		3/3	1		2017-09-10 23:25:36 +0900 JST	<none>				kube-system
kubernetes-dashboard-2jl6t				gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.3	Running		1/1	1		2017-09-10 23:25:36 +0900 JST	<none>				kube-system
db-migrate-koudaiii-2017091116251505114716-707pt	quay.io/koudaiii/myapp:946bd19					Succeeded	0/1	0		2017-09-11 16:16:56 +0900 JST	2017-09-11 16:29:01 +0900 JST	myapp
myapp-2136627869-2qlm1					quay.io/koudaiii/myapp:latest					Running		2/2	1		2017-09-11 18:07:43 +0900 JST	<none>				myapp
myapp-2136627869-2qlm1					nginx:1.13.3-alpine						Running		2/2	1		2017-09-11 18:07:43 +0900 JST	<none>				myapp
myapp-2136627869-6w3mj					quay.io/koudaiii/myapp:latest					Running		2/2	1		2017-09-11 18:06:26 +0900 JST	<none>				myapp
myapp-2136627869-6w3mj					nginx:1.13.3-alpine						Running		2/2	1		2017-09-11 18:06:26 +0900 JST	<none>				myapp
myapp-2136627869-dcvw3					quay.io/koudaiii/myapp:latest					Running		2/2	1		2017-09-11 18:07:20 +0900 JST	<none>				myapp
myapp-2136627869-dcvw3					nginx:1.13.3-alpine						Running		2/2	1		2017-09-11 18:07:20 +0900 JST	<none>				myapp
myapp-2136627869-kwlhx					quay.io/koudaiii/myapp:latest					Running		2/2	1		2017-09-11 18:06:26 +0900 JST	<none>				myapp
myapp-2136627869-kwlhx					nginx:1.13.3-alpine						Running		2/2	1		2017-09-11 18:06:26 +0900 JST	<none>				myapp
myapp-job-1505118600-sr7wn				quay.io/koudaiii/myapp:latest					Succeeded	0/1	0		2017-09-11 17:30:05 +0900 JST	2017-09-11 17:30:15 +0900 JST	myapp
myapp-job-1505119500-dgc2d				quay.io/koudaiii/myapp:latest					Succeeded	0/1	0		2017-09-11 17:45:06 +0900 JST	2017-09-11 17:45:15 +0900 JST	myapp
myapp-job-1505120400-zbp9s				quay.io/koudaiii/myapp:latest					Succeeded	0/1	0		2017-09-11 18:00:08 +0900 JST	2017-09-11 18:01:08 +0900 JST	myapp
myapp-job-1505121300-cjgrt				quay.io/koudaiii/myapp:latest					Succeeded	0/1	0		2017-09-11 18:15:01 +0900 JST	2017-09-11 18:15:09 +0900 JST	myapp
myapp-job-1505122200-0pn60				quay.io/koudaiii/myapp:latest					Succeeded	0/1	0		2017-09-11 18:30:02 +0900 JST	2017-09-11 18:30:10 +0900 JST	myapp
postgres-2312165663-5vzcs				postgres:9.6.5							Running		1/1	1		2017-09-11 09:52:18 +0900 JST	<none>				myapp
```